### PR TITLE
Add route to list todo items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # devops-todo-practice
 worker-todo-test
+
+## Endpoints
+
+- `GET /add?content=<text>`: Add a todo item and return the updated list.
+- `GET /list`: Retrieve all todo items.

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,15 @@ export default {
       });
     }
 
+    if (url.pathname === "/list") {
+      const rawList = await env.TODOS.get("list");
+      const list = rawList ? JSON.parse(rawList) : [];
+
+      return new Response(JSON.stringify(list), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     return new Response("Hello World!");
   },
 };


### PR DESCRIPTION
## Summary
- support `GET /list` to return todos
- document the routes in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845912c4cc4832aa5edec9fed2f457c